### PR TITLE
Allow Borrow<Result<V, E>> for result assertions

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,6 +29,7 @@ pub use crate::partial_eq::PartialEqAssertions;
 pub use crate::partial_ord::PartialOrdAssertions;
 pub use crate::pointer::PointerAssertions;
 pub use crate::result::{
+    OwnedResultAssertions,
     ResultAssertions,
     ResultErrorPartialEqAssertions,
     ResultValuePartialEqAssertions

--- a/src/result.rs
+++ b/src/result.rs
@@ -91,7 +91,7 @@ where
     where
         E: 'reference
     {
-        assert_is_ok(&self);
+        assert_is_ok(self);
 
         AssertThat {
             data: self.data.borrow().as_ref().unwrap(),
@@ -103,7 +103,7 @@ where
     where
         V: 'reference
     {
-        assert_is_err(&self);
+        assert_is_err(self);
 
         AssertThat {
             data: self.data.borrow().as_ref().unwrap_err(),

--- a/src/result.rs
+++ b/src/result.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 use crate::{AssertThat, Failure};
 
 /// An extension trait to be used on the output of [assert_that](crate::assert_that) with [Result]
-/// argument.
+/// argument. All assertions here work for references to [Result]s as well.
 ///
 /// Examples:
 ///
@@ -29,43 +29,115 @@ pub trait ResultAssertions<V, E> {
     fn is_err(self) -> Self;
 
     /// Asserts that the tested result is ok (see [ResultAssertions::is_ok]) and returns a new
-    /// [AssertThat] instance that allows assertions on its value.
-    fn to_value(self) -> AssertThat<V>;
+    /// [AssertThat] instance that allows assertions on a reference to its value.
+    fn to_value_ref<'reference>(&'reference self) -> AssertThat<&'reference V>
+    where
+        E: 'reference;
 
     /// Asserts that the tested result is an error (see [ResultAssertions::is_err]) and returns a
-    /// new [AssertThat] instance that allows assertions on its error.
-    fn to_error(self) -> AssertThat<E>;
+    /// new [AssertThat] instance that allows assertions on a reference to its error.
+    fn to_error_ref<'reference>(&'reference self) -> AssertThat<&'reference E>
+    where
+        V: 'reference;
 }
 
-impl<V, E> ResultAssertions<V, E> for AssertThat<Result<V, E>>
+fn assert_is_ok<V, E, R>(assert_that: &AssertThat<R>)
 where
     V: Debug,
-    E: Debug
+    E: Debug,
+    R: Borrow<Result<V, E>>
+{
+    if assert_that.data.borrow().is_err() {
+        Failure::new(assert_that)
+            .expected_it("to be ok")
+            .but_it(format!("was <{:?}>", assert_that.data.borrow()))
+            .fail();
+    }
+}
+
+fn assert_is_err<V, E, R>(assert_that: &AssertThat<R>)
+where
+    V: Debug,
+    E: Debug,
+    R: Borrow<Result<V, E>>
+{
+    if assert_that.data.borrow().is_ok() {
+        Failure::new(assert_that)
+            .expected_it("to be an error")
+            .but_it(format!("was <{:?}>", assert_that.data.borrow()))
+            .fail();
+    }
+}
+
+impl<V, E, R> ResultAssertions<V, E> for AssertThat<R>
+where
+    V: Debug,
+    E: Debug,
+    R: Borrow<Result<V, E>>
 {
     fn is_ok(self) -> Self {
-        if self.data.is_err() {
-            Failure::new(&self)
-                .expected_it("to be ok")
-                .but_it_was_data(&self)
-                .fail();
-        }
+        assert_is_ok(&self);
 
         self
     }
 
     fn is_err(self) -> Self {
-        if self.data.is_ok() {
-            Failure::new(&self)
-                .expected_it("to be an error")
-                .but_it_was_data(&self)
-                .fail();
-        }
+        assert_is_err(&self);
 
         self
     }
 
-    fn to_value(mut self) -> AssertThat<V> {
-        self = self.is_ok();
+    fn to_value_ref<'reference>(&'reference self) -> AssertThat<&'reference V>
+    where
+        E: 'reference
+    {
+        assert_is_ok(&self);
+
+        AssertThat {
+            data: self.data.borrow().as_ref().unwrap(),
+            expression: format!("value of <{}>", self.expression)
+        }
+    }
+
+    fn to_error_ref<'reference>(&'reference self) -> AssertThat<&'reference E>
+    where
+        V: 'reference
+    {
+        assert_is_err(&self);
+
+        AssertThat {
+            data: self.data.borrow().as_ref().unwrap_err(),
+            expression: format!("error of <{}>", self.expression)
+        }
+    }
+}
+
+/// An extension trait to be used on the output of [assert_that](crate::assert_that) with owned
+/// [Result] argument.
+///
+/// Examples:
+///
+/// ```
+/// use kernal::prelude::*;
+/// use std::str::FromStr;
+///
+/// assert_that!(u32::from_str("5")).to_value().is_greater_than(4);
+/// assert_that!(Err("message") as Result<u32, &str>).to_error().contains("mess");
+/// ```
+pub trait OwnedResultAssertions<V, E> {
+
+    /// Asserts that the tested result is ok (see [ResultAssertions::is_ok]) and returns a new
+    /// [AssertThat] instance that allows assertions on its owned value.
+    fn to_value(self) -> AssertThat<V>;
+
+    /// Asserts that the tested result is an error (see [ResultAssertions::is_err]) and returns a
+    /// new [AssertThat] instance that allows assertions on its owned error.
+    fn to_error(self) -> AssertThat<E>;
+}
+
+impl<V: Debug, E: Debug> OwnedResultAssertions<V, E> for AssertThat<Result<V, E>> {
+    fn to_value(self) -> AssertThat<V> {
+        assert_is_ok(&self);
 
         AssertThat {
             data: self.data.unwrap(),
@@ -73,8 +145,8 @@ where
         }
     }
 
-    fn to_error(mut self) -> AssertThat<E> {
-        self = self.is_err();
+    fn to_error(self) -> AssertThat<E> {
+        assert_is_err(&self);
 
         AssertThat {
             data: self.data.unwrap_err(),
@@ -84,7 +156,8 @@ where
 }
 
 /// An extension trait to be used on the output of [assert_that](crate::assert_that) with [Result]
-/// argument where the value type implements [PartialEq].
+/// argument where the value type implements [PartialEq]. All assertions here work for references to
+/// [Result]s as well.
 ///
 /// Examples:
 ///
@@ -106,28 +179,32 @@ pub trait ResultValuePartialEqAssertions<V, E> {
     fn does_not_contain_value<B: Borrow<V>>(self, unexpected: B) -> Self;
 }
 
-impl<V, E> ResultValuePartialEqAssertions<V, E> for AssertThat<Result<V, E>>
+impl<V, E, R> ResultValuePartialEqAssertions<V, E> for AssertThat<R>
 where
     V: Debug + PartialEq,
-    E: Debug
+    E: Debug,
+    R: Borrow<Result<V, E>>
 {
     fn contains_value<B: Borrow<V>>(self, expected: B) -> Self {
         let expected = expected.borrow();
 
-        match &self.data {
+        match self.data.borrow() {
             Ok(value) if value == expected => self,
             Ok(_) => Failure::new(&self)
                 .expected_it(format!("to contain the value <{:?}>", expected))
-                .but_it_was_data(&self)
+                .but_it(format!("was <{:?}>", self.data.borrow()))
                 .fail(),
-            Err(_) => Failure::new(&self).expected_it("to be ok").but_it_was_data(&self).fail()
+            Err(_) => Failure::new(&self)
+                .expected_it("to be ok")
+                .but_it(format!("was <{:?}>", self.data.borrow()))
+                .fail()
         }
     }
 
     fn does_not_contain_value<B: Borrow<V>>(self, unexpected: B) -> Self {
         let unexpected = unexpected.borrow();
 
-        if self.data.iter().any(|value| value == unexpected) {
+        if self.data.borrow().iter().any(|value| value == unexpected) {
             Failure::new(&self)
                 .expected_it(format!("not to be ok with the value <{:?}>", unexpected))
                 .but_it("was")
@@ -139,7 +216,8 @@ where
 }
 
 /// An extension trait to be used on the output of [assert_that](crate::assert_that) with [Result]
-/// argument where the error type implements [PartialEq].
+/// argument where the error type implements [PartialEq]. All assertions here work for references to
+/// [Result]s as well.
 ///
 /// Examples:
 ///
@@ -164,27 +242,31 @@ pub trait ResultErrorPartialEqAssertions<V, E> {
     fn does_not_contain_error<B: Borrow<E>>(self, unexpected: B) -> Self;
 }
 
-impl<V, E> ResultErrorPartialEqAssertions<V, E> for AssertThat<Result<V, E>>
+impl<V, E, R> ResultErrorPartialEqAssertions<V, E> for AssertThat<R>
 where
     V: Debug,
-    E: Debug + PartialEq
+    E: Debug + PartialEq,
+    R: Borrow<Result<V, E>>
 {
     fn contains_error<B: Borrow<E>>(self, expected: B) -> Self {
         let expected = expected.borrow();
 
-        match &self.data {
+        match self.data.borrow() {
             Err(error) if error == expected => self,
             Err(_) => Failure::new(&self)
                 .expected_it(format!("to contain the error <{:?}>", expected))
-                .but_it_was_data(&self)
+                .but_it(format!("was <{:?}>", self.data.borrow()))
                 .fail(),
-            Ok(_) => Failure::new(&self).expected_it("to be an error").but_it_was_data(&self).fail()
+            Ok(_) => Failure::new(&self)
+                .expected_it("to be an error")
+                .but_it(format!("was <{:?}>", self.data.borrow()))
+                .fail()
         }
     }
 
     fn does_not_contain_error<B: Borrow<E>>(self, unexpected: B) -> Self {
         let unexpected = unexpected.borrow();
-        let contains_unexpected_error = match &self.data {
+        let contains_unexpected_error = match self.data.borrow() {
             Err(error) => error == unexpected,
             _ => false
         };
@@ -209,7 +291,7 @@ mod tests {
     fn is_ok_passes_for_ok() {
         let result: Result<u32, u32> = Ok(5);
 
-        assert_that!(result).is_ok();
+        assert_that!(&result).is_ok();
     }
 
     #[test]
@@ -223,7 +305,7 @@ mod tests {
     fn is_err_passes_for_err() {
         let result: Result<u32, u32> = Err(10);
 
-        assert_that!(result).is_err();
+        assert_that!(&result).is_err();
     }
 
     #[test]
@@ -234,47 +316,91 @@ mod tests {
     }
 
     #[test]
-    fn to_value_works_for_ok() {
+    fn to_value_ref_works_for_ok() {
         let result: Result<u32, u32> = Ok(42);
 
-        assert_that!(result).to_value().is_equal_to(42);
+        assert_that!(&result).to_value_ref().is_equal_to(&42);
+    }
+
+    #[test]
+    fn to_value_ref_has_the_correct_expression() {
+        let result: Result<u32, u32> = Ok(42);
+        let expression = assert_that!(result).to_value_ref().expression;
+
+        assert_that!(expression.as_str()).is_equal_to("value of <result>");
+    }
+
+    #[test]
+    fn to_value_ref_panics_for_err() {
+        let result: Result<u32, u32> = Err(23);
+
+        assert_fails!((result).to_value_ref(), expected it "to be ok" but it "was <Err(23)>");
+    }
+
+    #[test]
+    fn to_error_ref_works_for_err() {
+        let result: Result<u32, u32> = Err(23);
+
+        assert_that!(&result).to_error_ref().is_equal_to(&23);
+    }
+
+    #[test]
+    fn to_error_ref_has_the_correct_expression() {
+        let result: Result<u32, u32> = Err(23);
+        let expression = assert_that!(result).to_error_ref().expression;
+
+        assert_that!(expression.as_str()).is_equal_to("error of <result>");
+    }
+
+    #[test]
+    fn to_error_ref_panics_for_ok() {
+        let result: Result<u32, u32> = Ok(42);
+
+        assert_fails!((result).to_error_ref(), expected it "to be an error" but it "was <Ok(42)>");
+    }
+
+    #[test]
+    fn to_value_works_for_ok() {
+        let result: Result<u32, u32> = Ok(36);
+
+        assert_that!(&result).to_value_ref().is_equal_to(&36);
     }
 
     #[test]
     fn to_value_has_the_correct_expression() {
-        let result: Result<u32, u32> = Ok(42);
-        let expression = assert_that!(result).to_value().expression;
+        let result: Result<u32, u32> = Ok(36);
+        let expression = assert_that!(result).to_value_ref().expression;
 
         assert_that!(expression.as_str()).is_equal_to("value of <result>");
     }
 
     #[test]
     fn to_value_panics_for_err() {
-        let result: Result<u32, u32> = Err(23);
+        let result: Result<u32, u32> = Err(42);
 
-        assert_fails!((result).to_value(), expected it "to be ok" but it "was <Err(23)>");
+        assert_fails!((result).to_value_ref(), expected it "to be ok" but it "was <Err(42)>");
     }
 
     #[test]
     fn to_error_works_for_err() {
-        let result: Result<u32, u32> = Err(23);
+        let result: Result<u32, u32> = Err(42);
 
-        assert_that!(result).to_error().is_equal_to(23);
+        assert_that!(&result).to_error_ref().is_equal_to(&42);
     }
 
     #[test]
     fn to_error_has_the_correct_expression() {
-        let result: Result<u32, u32> = Err(23);
-        let expression = assert_that!(result).to_error().expression;
+        let result: Result<u32, u32> = Err(36);
+        let expression = assert_that!(result).to_error_ref().expression;
 
         assert_that!(expression.as_str()).is_equal_to("error of <result>");
     }
 
     #[test]
     fn to_error_panics_for_ok() {
-        let result: Result<u32, u32> = Ok(42);
+        let result: Result<u32, u32> = Ok(36);
 
-        assert_fails!((result).to_error(), expected it "to be an error" but it "was <Ok(42)>");
+        assert_fails!((result).to_error_ref(), expected it "to be an error" but it "was <Ok(36)>");
     }
 
     #[test]
@@ -288,7 +414,7 @@ mod tests {
     fn contains_value_fails_for_ok_with_incorrect_value() {
         let result: Result<u32, u32> = Ok(420);
 
-        assert_fails!((result).contains_value(1337),
+        assert_fails!((&result).contains_value(1337),
             expected it "to contain the value <1337>"
             but it "was <Ok(420)>");
     }
@@ -306,7 +432,7 @@ mod tests {
     fn does_not_contain_value_passes_for_ok_with_incorrect_value() {
         let result: Result<u32, u32> = Ok(420);
 
-        assert_that!(result).does_not_contain_value(1337);
+        assert_that!(&result).does_not_contain_value(1337);
     }
 
     #[test]
@@ -320,7 +446,7 @@ mod tests {
     fn does_not_contain_value_fails_for_ok_with_correct_value() {
         let result: Result<u32, u32> = Ok(420);
 
-        assert_fails!((result).does_not_contain_value(420),
+        assert_fails!((&result).does_not_contain_value(420),
             expected it "not to be ok with the value <420>"
             but it "was");
     }
@@ -336,7 +462,7 @@ mod tests {
     fn contains_error_fails_for_err_with_incorrect_error() {
         let result: Result<u32, u32> = Err(420);
 
-        assert_fails!((result).contains_error(1337),
+        assert_fails!((&result).contains_error(1337),
             expected it "to contain the error <1337>"
             but it "was <Err(420)>");
     }
@@ -354,7 +480,7 @@ mod tests {
     fn does_not_contain_error_passes_for_err_with_incorrect_error() {
         let result: Result<u32, u32> = Err(420);
 
-        assert_that!(result).does_not_contain_error(1337);
+        assert_that!(&result).does_not_contain_error(1337);
     }
 
     #[test]
@@ -368,7 +494,7 @@ mod tests {
     fn does_not_contain_error_fails_for_err_with_correct_error() {
         let result: Result<u32, u32> = Err(1337);
 
-        assert_fails!((result).does_not_contain_error(1337),
+        assert_fails!((&result).does_not_contain_error(1337),
             expected it "not to be the error <1337>"
             but it "was");
     }


### PR DESCRIPTION
This applies to `ResultAssertions`, `ResultValuePartialEqAssertions`, and `ResultErrorPartialEqAssertions`. In addition, the `to_value` and `to_error` methods now return asserters on the appropriate references and were renamed to `to_value_ref` and `to_error_ref` respectively. `OwnedResultAssertions` was added to contain `to_value` and `to_error` on owned results.

This resolves #42 